### PR TITLE
fix : 로그인 기능 수정

### DIFF
--- a/src/main/java/com/example/community_feed/commons/constant/Role.java
+++ b/src/main/java/com/example/community_feed/commons/constant/Role.java
@@ -4,5 +4,19 @@ import lombok.Getter;
 
 @Getter
 public enum Role {
-    ADMIN,USER
+    ADMIN("ADMIN"), USER("USER");
+    private final String name;
+
+    Role(String name) {
+        this.name = name;
+    }
+
+    public static Role of(String name) {
+        for (Role role : Role.values()) {
+            if (role.name.equals(name)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("유효하지 않은 역할");
+    }
 }

--- a/src/main/java/com/example/community_feed/commons/filter/LoginFilter.java
+++ b/src/main/java/com/example/community_feed/commons/filter/LoginFilter.java
@@ -1,17 +1,27 @@
 package com.example.community_feed.commons.filter;
 
+import com.example.community_feed.commons.constant.Role;
+import com.example.community_feed.user.CustomUser;
+import com.example.community_feed.util.JwtUtil;
+import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
 
 
     @Override
@@ -20,5 +30,26 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String password = obtainPassword(request);
         UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(email, password, null);
         return authenticationManager.authenticate(usernamePasswordAuthenticationToken);
+    }
+
+    @Override
+    public void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        CustomUser customUser = (CustomUser) authResult.getPrincipal();
+        String email = customUser.getUsername();
+        Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority authority = iterator.next();
+
+        String role = authority.getAuthority();
+        Role userRole = Role.valueOf(role.replace("ROLE_", ""));
+        String token = jwtUtil.generateToken(email, userRole);
+
+        response.addHeader("Authorization", "Bearer " + token);
+
+    }
+
+    @Nullable
+    protected String obtainUsername(HttpServletRequest request) {
+        return request.getParameter("email");
     }
 }

--- a/src/main/java/com/example/community_feed/config/SecurityConfig.java
+++ b/src/main/java/com/example/community_feed/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.community_feed.config;
 
 import com.example.community_feed.commons.filter.LoginFilter;
+import com.example.community_feed.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +11,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -21,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
 
     // todo 경로 별 인가 작업
 
@@ -55,10 +56,10 @@ public class SecurityConfig {
 
         httpSecurity
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/api/users/**", "/signup", "/login").permitAll()
+                        .requestMatchers("/api/users/signup").permitAll()
                         .anyRequest().authenticated());
 
-        httpSecurity.addFilterAt(new LoginFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class);
+        httpSecurity.addFilterAt(new LoginFilter(authenticationManager(), jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/example/community_feed/user/CustomUser.java
+++ b/src/main/java/com/example/community_feed/user/CustomUser.java
@@ -2,10 +2,12 @@ package com.example.community_feed.user;
 
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
+
 @Getter
 public class CustomUser implements UserDetails {
 
@@ -17,21 +19,16 @@ public class CustomUser implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new GrantedAuthority() {
-            @Override
-            public String getAuthority() {
-                return user.getRole().name();
-            }
-        });
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
     }
 
     @Override
     public String getPassword() {
-        return "";
+        return user.getPassword();
     }
 
     @Override
     public String getUsername() {
-        return "";
+        return user.getEmail();
     }
 }

--- a/src/main/java/com/example/community_feed/user/UserController.java
+++ b/src/main/java/com/example/community_feed/user/UserController.java
@@ -20,11 +20,4 @@ public class UserController {
         userService.signup(signUpRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 성공");
     }
-
-    @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody UserRequestDto.LoginRequestDto loginRequestDto) {
-        String token = userService.login(loginRequestDto);
-        return ResponseEntity.status(HttpStatus.OK).body(token);
-    }
-
 }

--- a/src/main/java/com/example/community_feed/user/UserService.java
+++ b/src/main/java/com/example/community_feed/user/UserService.java
@@ -1,7 +1,6 @@
 package com.example.community_feed.user;
 
 import com.example.community_feed.commons.constant.Role;
-import com.example.community_feed.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
-    private final JwtUtil jwtUtil;
 
     public void signup(UserRequestDto.SignUpRequestDto signUpRequestDto) {
         boolean isExisted = userRepository.existsUserByEmail(signUpRequestDto.getEmail());
@@ -37,18 +35,5 @@ public class UserService implements UserDetailsService {
         User user = userRepository.findByEmail(username).orElseThrow(() -> new IllegalArgumentException("유효한 사용자가 아닙니다"));
         return new CustomUser(user);
 
-    }
-
-    public String login(UserRequestDto.LoginRequestDto loginRequestDto) {
-
-        User user = userRepository.findByEmail(loginRequestDto.getEmail()).orElseThrow(() -> new IllegalArgumentException("로그인 실패"));
-        boolean isMatched = passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword());
-        if (!isMatched) {
-            throw new IllegalArgumentException("유효한 사용자 정보가 아닙니다");
-        }
-
-        log.info("로그인한 사용자 : {}", user.getEmail());
-
-        return jwtUtil.generateToken(user.getEmail(),user.getRole());
     }
 }


### PR DESCRIPTION
UsernamePasswordAuthenticationFilter 필터가 기본적으로 /login 을 자동적으로 처리하여 컨트롤러, 서비스 제거 및 LoginFilter 수정

## 개요
- UsernamePasswordAuthenticationFilter 필터가 기본적으로 /login 을 자동적으로 처리하여 수동으로 /login 만들어 준것을 삭제 하였습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 📸스크린샷
![image](https://github.com/user-attachments/assets/0a8a4606-5ea5-4a3e-bb0c-dba07e23e4e2)



## 💬 공유사항 to 리뷰어
UsernamePasswordAuthenticationFilter를 상속해서 필터를 커스터마이징 해서 /login을 처리되게 했는데 필터를 상속하지말고 login 관련 컨트롤러를 만드는게 나은것 인지 궁금합니다.



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
